### PR TITLE
Old props and children added as argument to custom component patch method

### DIFF
--- a/src/vdom.js
+++ b/src/vdom.js
@@ -215,11 +215,17 @@ export function patch(newch, oldch, parent) {
   } else if (oldch.type === newch.type && oldch.isSVG === newch.isSVG) {
     const { type, isSVG } = oldch;
     if (isComponent(type)) {
-      type.patch(childNode, newch.props, newch.content);
+      type.patch(
+        childNode,
+        newch.props,
+        oldch.props,
+        newch.content,
+        oldch.content
+      );
     } else if (typeof type === "function") {
       var shouldUpdateFn = type.shouldUpdate || defShouldUpdate;
       if (
-        shouldUpdateFn(oldch.props, newch.props, oldch.content, newch.content)
+        shouldUpdateFn(newch.props, oldch.props, newch.content, oldch.content)
       ) {
         var vnode = type(newch.props, newch.content);
         childNode = patch(vnode, oldch._data, parent);

--- a/test/patch.test.js
+++ b/test/patch.test.js
@@ -278,9 +278,11 @@ test("Patch Component", assert => {
       node._payload = [props, content];
       return node;
     },
-    patch: (node, props, content) => {
+    patch: (node, props, oldProps, content, oldContent) => {
       patchCalls++;
       node._payload = [props, content];
+      assert.deepEqual(oldProps, vnode.props);
+      assert.deepEqual(oldContent, vnode.content);
       return node;
     },
     unmount: () => {}


### PR DESCRIPTION
- Added oldProps and oldChildren parameters to custom component patch method;
- Switch argument places in shouldUpdate method to keep it consistent with path method.